### PR TITLE
Adding Koa-mongoose-api to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ This is a code base of todo-api's examples written in ES6 for study purposes.
 * **hapi-knex-api**
 * **hapi-couchdb-api**
 * **hapi-neo4j-api**
-* **koa-mongoose-api**
 * **koa-knex-api**
 * **koa-sequelize-api**
 * **koa-leveldb-api**
@@ -57,6 +56,7 @@ New project's are welcome! If you want to contribute, please [click here to foll
 - Caio Ribeiro Pereira - [@crp_underground](https://twitter.com/crp_underground)
 - Beto Muniz - [betomuniz.com](http://betomuniz.com)
 - Itacir Ferreira Pompeu- [pompeu.github.io](http://pompeu.github.io)
+- Manoel Freitas - [laedanthehuman](laedanthehuman.github.io)
 
 ## License
 

--- a/koa-mongoose-api/.babelrc
+++ b/koa-mongoose-api/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-regenerator"]
+}

--- a/koa-mongoose-api/.eslintignore
+++ b/koa-mongoose-api/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+package.json

--- a/koa-mongoose-api/.eslintrc
+++ b/koa-mongoose-api/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": "airbnb-base",
+  "rules" : {
+    "comma-dangle": [2, "never"],
+    "indent": ["error", 2],
+    "prefer-template": 2,
+    "no-console": 0,
+    "new-cap": 0,
+    "no-underscore-dangle": 0,
+    "global-require": 0,
+    "func-names": 0,
+    "generator-star-spacing": 0
+  }
+}

--- a/koa-mongoose-api/.gitignore
+++ b/koa-mongoose-api/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+npm-debug.log

--- a/koa-mongoose-api/config.js
+++ b/koa-mongoose-api/config.js
@@ -1,0 +1,3 @@
+const { NODE_ENV } = process.env;
+const config = `./config/config.${NODE_ENV || 'development'}.js`;
+module.exports = require(config);

--- a/koa-mongoose-api/config/config.development.js
+++ b/koa-mongoose-api/config/config.development.js
@@ -1,0 +1,16 @@
+export default {
+  isTest: false,
+  server: {
+    port: 3000,
+    host: 'localhost'
+  },
+  bodyParser: {
+    extended: true
+  },
+  mongodb: {
+    uri: 'mongodb://localhost:27017/express_mongodb'
+  },
+  consign: {
+    verbose: false
+  }
+};

--- a/koa-mongoose-api/config/config.test.js
+++ b/koa-mongoose-api/config/config.test.js
@@ -1,0 +1,16 @@
+export default {
+  isTest: true,
+  server: {
+    port: 3000,
+    host: 'localhost'
+  },
+  bodyParser: {
+    extended: true
+  },
+  mongodb: {
+    uri: 'mongodb://localhost:27017/express_mongodb_test'
+  },
+  consign: {
+    verbose: false
+  }
+};

--- a/koa-mongoose-api/index.js
+++ b/koa-mongoose-api/index.js
@@ -1,0 +1,34 @@
+import 'babel-polyfill';
+import consign from 'consign';
+import koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import compress from 'koa-compress';
+import config from './config.js';
+import mongoose from 'mongoose';
+import Bluebird from 'bluebird';
+
+
+const app = koa();
+
+mongoose.connect(config.mongodb.uri);
+mongoose.Promise = Bluebird;
+
+app.use(bodyParser());
+
+
+consign(config.consign)
+  .include('models')
+  .then('routes')
+  .into(app)
+;
+
+app.use(compress());
+
+app.listen(config.server.port, () => {
+  if (!config.isTest) {
+    console.log('Koa-mongoose TODO  API');
+    console.log(`Address: ${config.server.host}:${config.server.port}`);
+  }
+});
+
+export default app;

--- a/koa-mongoose-api/models/tasks.js
+++ b/koa-mongoose-api/models/tasks.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+module.exports = () => {
+  const schema = new mongoose.Schema({
+    name: { type: String, trim: true, required: true },
+    done: { type: Boolean }
+  });
+  return mongoose.model('tasks', schema);
+};

--- a/koa-mongoose-api/package.json
+++ b/koa-mongoose-api/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "koa",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "NODE_ENV=development nodemon index.js --exec babel-node",
+    "test": "NODE_ENV=test mocha test/**/*.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "babel-polyfill": "6.9.1",
+    "bluebird": "^3.4.7",
+    "chai": "3.5.0",
+    "consign": "0.1.2",
+    "koa": "1.2.0",
+    "koa-bodyparser": "2.2.0",
+    "koa-compress": "1.0.9",
+    "koa-router": "5.4.0",
+    "lx-valid": "1.2.0",
+    "mongoose": "4.5.3",
+    "supertest": "1.2.0"
+  },
+  "devDependencies": {
+    "babel-cli": "6.10.1",
+    "babel-core": "6.10.4",
+    "babel-plugin-transform-regenerator": "6.9.0",
+    "babel-preset-es2015": "6.9.0",
+    "eslint": "3.0.1",
+    "eslint-config-airbnb-base": "4.0.0",
+    "eslint-plugin-import": "1.10.2",
+    "mocha": "2.5.3",
+    "nodemon": "1.9.2"
+  }
+}

--- a/koa-mongoose-api/routes/tasks.js
+++ b/koa-mongoose-api/routes/tasks.js
@@ -1,0 +1,65 @@
+import Router from 'koa-router';
+
+module.exports = app => {
+    const Tasks = app.models.tasks;
+    const router = new Router();
+
+    router
+        .get('/tasks', function* () {
+            try {
+                const tasks = yield Tasks.find({});
+                this.body = tasks;
+            } catch (err) {
+                this.throw(412, { err });
+            }
+        })
+        .get('/tasks/:taskId', function* () {
+            try {
+                const taskId = this.params.taskId;
+                const task = yield Tasks.findById(taskId);
+                if (task) {
+                    this.body = task;
+                } else {
+                    this.status = 404;
+                }
+            } catch (err) {
+                this.throw(412, { err });
+            }
+        })
+        .post('/tasks', function* () {
+            try {
+                const task = this.request.body;
+                this.body = yield Tasks.create(task);
+            } catch (err) {
+                this.throw(412, { err });
+            }
+        })
+        .put('/tasks/:taskId', function* () {
+            try {
+                const taskId = this.params.taskId;
+                const task = this.request.body;
+                yield Tasks.update({ _id: taskId }, { $set: task });
+                const taskUpdated = yield Tasks.findById(taskId);
+                if (taskUpdated) {
+                    this.body = taskUpdated;
+                } else {
+                    this.status = 404;
+                }
+            } catch (err) {
+                this.throw(412, { err });
+            }
+        })
+        .delete('/tasks/:taskId', function* () {
+            try {
+                const taskId = this.params.taskId;
+                yield Tasks.findByIdAndRemove(taskId);
+                this.status = 204;
+            } catch (err) {
+                this.throw(412, { err });
+            }
+        })
+        ;
+
+    app.use(router.routes());
+    app.use(router.allowedMethods());
+};

--- a/koa-mongoose-api/test/helpers.js
+++ b/koa-mongoose-api/test/helpers.js
@@ -1,0 +1,10 @@
+import 'babel-polyfill';
+import supertest from 'supertest';
+import chai from 'chai';
+import app from '../index.js';
+import config from '../config.js';
+
+global.app = app;
+global.config = config;
+global.expect = chai.expect;
+global.request = supertest(app.listen());

--- a/koa-mongoose-api/test/mocha.opts
+++ b/koa-mongoose-api/test/mocha.opts
@@ -1,0 +1,4 @@
+--require test/helpers
+--reporter spec
+--compilers js:babel-register
+--slow 7500

--- a/koa-mongoose-api/test/routes/tasks.js
+++ b/koa-mongoose-api/test/routes/tasks.js
@@ -1,0 +1,92 @@
+/* global describe, before, after, beforeEach, it */
+/* global expect, app, config, request */
+
+describe('Routes: Tasks', () => {
+    const Tasks = app.models.tasks;
+    const tasks = [
+        { _id: '577c68c99c1c91dd96db5637', name: 'study hard!', done: false },
+        { _id: '577c68ff9c1c91dd96db5638', name: 'work soft!', done: false }
+    ];
+
+    beforeEach(done => {
+        Tasks.remove({}, () => Tasks.insertMany(tasks, done));
+    });
+
+    describe('GET /tasks', () => {
+        describe('status 200', () => {
+            it('returns a list of tasks', done => {
+                request.get('/tasks')
+                    .expect(200)
+                    .end((err, res) => {
+                        expect(res.body).to.have.length(2);
+                        expect(res.body).to.include(tasks[0]);
+                        expect(res.body).to.include(tasks[1]);
+                        done(err);
+                    });
+            });
+        });
+    });
+
+    describe('POST /tasks', () => {
+        describe('status 200', () => {
+            it('creates a new task', done => {
+                request.post('/tasks')
+                    .send({ name: 'run fast!', done: false })
+                    .expect(200)
+                    .end((err, res) => {
+                        expect(res.body.name).to.eql('run fast!');
+                        expect(res.body.done).to.eql(false);
+                        done(err);
+                    });
+            });
+        });
+    });
+
+    describe('GET /tasks/:id', () => {
+        describe('status 200', () => {
+            it('returns one task', done => {
+                request.get(`/tasks/${tasks[0]._id}`)
+                    .expect(200)
+                    .end((err, res) => {
+                        expect(res.body._id).to.eql(tasks[0]._id);
+                        expect(res.body.name).to.eql(tasks[0].name);
+                        expect(res.body.done).to.eql(tasks[0].done);
+                        done(err);
+                    });
+            });
+        });
+        describe('status 404', () => {
+            it('throws error when task not exist', done => {
+                request.get('/tasks/id-not-exist')
+                    .expect(404)
+                    .end(err => done(err));
+            });
+        });
+    });
+
+    describe('PUT /tasks/:id', () => {
+        describe('status 200', () => {
+            it('updates a task', done => {
+                request.put(`/tasks/${tasks[0]._id}`)
+                    .send({ name: 'travel a lot!', done: true })
+                    .expect(200)
+                    .end((err, res) => {
+                        expect(res.body._id).to.eql(tasks[0]._id);
+                        expect(res.body.name).to.eql('travel a lot!');
+                        expect(res.body.done).to.eql(true);
+                        done(err);
+                    });
+            });
+        });
+    });
+
+    describe('DELETE /tasks/:id', () => {
+        describe('status 204', () => {
+            it('removes a task', done => {
+                request.delete(`/tasks/${tasks[0]._id}`)
+                    .expect(204)
+                    .end(err => done(err));
+            });
+        });
+    });
+});


### PR DESCRIPTION
- Junção dos projetos express-mongoose-api com koa-rethinkdb-api
- Alteração nas promises do mongoose para se adequar ao mongoose 4 onde ele pede que para usar es6 generators devemos conectar nossa lib de promises preferida (bluebird) [Ver mais aqui] (http://mongoosejs.com/docs/promises.html)
-Cumprindo todas os requisitos do colaborators guide 